### PR TITLE
feat: onion message resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,28 +99,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,12 +122,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "axum"
-version = "0.7.9"
+name = "aws-lc-rs"
+version = "1.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "dabb68eb3a7aa08b46fddfd59a3d55c978243557a90ab804769f7e20e67d2b01"
 dependencies = [
- "async-trait",
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77926887776171ced7d662120a75998e444d3750c951abfe07f90da130514b1f"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
@@ -165,18 +165,17 @@ dependencies = [
  "rustversion",
  "serde",
  "sync_wrapper",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
 dependencies = [
- "async-trait",
  "bytes",
  "futures-util",
  "http",
@@ -232,6 +231,29 @@ name = "bech32"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+ "which",
+]
 
 [[package]]
 name = "bitcoin"
@@ -361,6 +383,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +410,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -416,6 +458,15 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -585,6 +636,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +705,12 @@ name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -781,6 +844,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "h2"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,18 +861,12 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.8.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -877,6 +940,15 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tonic-build",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1148,22 +1220,21 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1207,6 +1278,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,6 +1299,16 @@ dependencies = [
  "libc",
  "libz-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1290,6 +1377,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
@@ -1312,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "matchers"
@@ -1327,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -1552,7 +1645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.8.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -1689,7 +1782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -1709,7 +1802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1862,12 +1955,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1879,7 +1991,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.3",
  "windows-sys 0.59.0",
 ]
 
@@ -1889,22 +2001,13 @@ version = "0.23.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -1915,10 +2018,11 @@ checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.0"
+version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
+checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2017,7 +2121,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -2128,7 +2232,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 1.0.2",
  "windows-sys 0.59.0",
 ]
 
@@ -2297,7 +2401,7 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2306,11 +2410,10 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "85839f0b32fd242bb3209262371d07feda6d780d16ee9d2bc88581b89da1549b"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
  "base64",
@@ -2326,12 +2429,11 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "rustls-pemfile",
  "socket2",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2340,9 +2442,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "d85f0383fadd15609306383a90e85eaed44169f931a5d2be1b42c76ceff1825e"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2354,36 +2456,21 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2593,6 +2680,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,11 @@ diesel = { version = "2.2.6", features = [
     "sqlite",
 ] }
 diesel_migrations = "2.2.0"
-log = { version = "0.4.25", features = [] }
+log = { version = "0.4.27", features = [] }
 prost = "0.13.4"
 rcgen = { version = "0.13.2", features = ["x509-parser"] }
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread", "sync"] }
-tonic = { version = "0.12.3", features = ["prost", "tls", "gzip", "zstd"] }
+tonic = { version = "0.13.0", features = ["prost", "gzip", "zstd", "tls-aws-lc"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = { version = "1.0.137", features = ["preserve_order"] }
 lightning-invoice = { version = "0.33.0", features = ["std"] }
@@ -42,7 +42,7 @@ bech32 = "0.11.0"
 
 [build-dependencies]
 built = { version = "0.7.5", features = ["git2"] }
-tonic-build = "0.12.3"
+tonic-build = "0.13.0"
 
 [dev-dependencies]
 mockall = "0.13.1"

--- a/protos/hold.proto
+++ b/protos/hold.proto
@@ -19,7 +19,12 @@ service Hold {
   rpc Track (TrackRequest) returns (stream TrackResponse) {}
   rpc TrackAll (TrackAllRequest) returns (stream TrackAllResponse) {}
 
-  rpc OnionMessages (OnionMessagesRequest) returns (stream OnionMessage) {}
+  rpc OnionMessages (stream OnionMessageResponse) returns (stream OnionMessage) {}
+}
+
+enum HookAction {
+  Continue = 0;
+  Resolve = 1;
 }
 
 message GetInfoRequest {}
@@ -145,7 +150,6 @@ message TrackAllResponse {
   InvoiceState state = 3;
 }
 
-message OnionMessagesRequest {}
 message OnionMessage {
   message ReplyBlindedPath {
     message Hop {
@@ -165,10 +169,16 @@ message OnionMessage {
     bytes value = 2;
   }
 
-  optional bytes pathsecret = 1;
-  optional ReplyBlindedPath reply_blindedpath = 2;
-  optional bytes invoice_request = 3;
-  optional bytes invoice = 4;
-  optional bytes invoice_error = 5;
-  repeated UnknownField unknown_fields = 6;
+  uint64 id = 1;
+  optional bytes pathsecret = 2;
+  optional ReplyBlindedPath reply_blindedpath = 3;
+  optional bytes invoice_request = 4;
+  optional bytes invoice = 5;
+  optional bytes invoice_error = 6;
+  repeated UnknownField unknown_fields = 7;
+}
+
+message OnionMessageResponse {
+  uint64 id = 1;
+  HookAction action = 2;
 }

--- a/src/grpc/transformers.rs
+++ b/src/grpc/transformers.rs
@@ -99,6 +99,7 @@ impl TryFrom<OnionMessage> for hold::OnionMessage {
 
     fn try_from(value: OnionMessage) -> Result<Self, Self::Error> {
         Ok(Self {
+            id: value.id(),
             pathsecret: hex_from_str(value.pathsecret)?,
             reply_blindedpath: value
                 .reply_blindedpath

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,17 +43,6 @@ async fn main() -> Result<()> {
         );
     }
 
-    info!(
-        "Starting plugin {}-{}{}",
-        utils::built_info::PKG_VERSION,
-        utils::built_info::GIT_COMMIT_HASH_SHORT.unwrap_or(""),
-        if utils::built_info::GIT_DIRTY.unwrap_or(false) {
-            "-dirty"
-        } else {
-            ""
-        }
-    );
-
     let plugin = match Builder::new(tokio::io::stdin(), tokio::io::stdout())
         .dynamic()
         .option(OPTION_DATABASE)
@@ -156,6 +145,17 @@ async fn main() -> Result<()> {
     if !plugin_dir.exists() {
         fs::create_dir(plugin_dir)?;
     }
+
+    info!(
+        "Starting plugin {}-{}{}",
+        utils::built_info::PKG_VERSION,
+        utils::built_info::GIT_COMMIT_HASH_SHORT.unwrap_or(""),
+        if utils::built_info::GIT_DIRTY.unwrap_or(false) {
+            "-dirty"
+        } else {
+            ""
+        }
+    );
 
     let db = match database::connect(&db_url) {
         Ok(db) => db,

--- a/src/messenger.rs
+++ b/src/messenger.rs
@@ -1,0 +1,165 @@
+use crate::hooks::{OnionMessage, onion_message::OnionMessageResponse};
+use log::trace;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+use std::time::SystemTime;
+use tokio::sync::broadcast;
+use tokio::sync::oneshot;
+
+const MESSAGE_TIMEOUT: u64 = 30;
+
+type PendingMessages =
+    Arc<Mutex<HashMap<u64, (SystemTime, oneshot::Sender<OnionMessageResponse>)>>>;
+
+#[derive(Clone)]
+pub struct Messenger {
+    tx: broadcast::Sender<OnionMessage>,
+    pending_messages: PendingMessages,
+}
+
+impl Messenger {
+    pub fn new() -> Self {
+        let (tx, _) = broadcast::channel(1024);
+        Self {
+            tx,
+            pending_messages: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub async fn timeout_loop(&self) {
+        let mut interval = tokio::time::interval(Duration::from_secs(MESSAGE_TIMEOUT));
+        trace!(
+            "Timing out pending onion messages every {} seconds",
+            MESSAGE_TIMEOUT
+        );
+        loop {
+            interval.tick().await;
+            self.check_timeouts();
+        }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<OnionMessage> {
+        self.tx.subscribe()
+    }
+
+    pub fn send_response(&self, id: u64, response: OnionMessageResponse) {
+        if let Some((_, tx)) = self.pending_messages.lock().unwrap().remove(&id) {
+            trace!("Sending response to onion message: {}", id);
+            let _ = tx.send(response);
+        }
+    }
+
+    pub fn received_message(
+        &self,
+        message: OnionMessage,
+    ) -> oneshot::Receiver<OnionMessageResponse> {
+        let (tx, rx) = oneshot::channel();
+        trace!("Received onion message: {}", message.id());
+        self.pending_messages
+            .lock()
+            .unwrap()
+            .insert(message.id(), (SystemTime::now(), tx));
+        let _ = self.tx.send(message);
+
+        rx
+    }
+
+    fn check_timeouts(&self) {
+        let mut keys_to_remove = Vec::new();
+        let now = SystemTime::now();
+
+        let mut pending_messages = self.pending_messages.lock().unwrap();
+        for (id, (time, _)) in pending_messages.iter_mut() {
+            if now.duration_since(*time).unwrap() > Duration::from_secs(MESSAGE_TIMEOUT) {
+                keys_to_remove.push(*id);
+            }
+        }
+
+        for key in keys_to_remove {
+            let (_, tx) = pending_messages.remove(&key).unwrap();
+            trace!("Timed out pending onion message: {}", key);
+            let _ = tx.send(OnionMessageResponse::Continue);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hooks::onion_message::UnknownField;
+
+    fn create_test_message(id: u64, data: Vec<u8>) -> OnionMessage {
+        OnionMessage {
+            pathsecret: Some(format!("secret_{}", id)),
+            reply_blindedpath: None,
+            invoice_request: None,
+            invoice: None,
+            invoice_error: None,
+            unknown_fields: vec![UnknownField {
+                number: 1,
+                value: hex::encode(&data),
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn test_message_sending_and_receiving() {
+        let messenger = Messenger::new();
+        let mut rx = messenger.subscribe();
+
+        let test_message = create_test_message(1, vec![1, 2, 3]);
+        let response_rx = messenger.received_message(test_message.clone());
+
+        let received_message = rx.recv().await.unwrap();
+        assert_eq!(received_message.id(), test_message.id());
+
+        messenger.send_response(test_message.id(), OnionMessageResponse::Continue);
+
+        let response = response_rx.await.unwrap();
+        assert_eq!(response, OnionMessageResponse::Continue);
+    }
+
+    #[tokio::test]
+    async fn test_message_timeout() {
+        let messenger = Messenger::new();
+        let test_message = create_test_message(1, vec![1, 2, 3]);
+
+        let (tx, rx) = oneshot::channel();
+        let fake_time = SystemTime::now() - Duration::from_secs(MESSAGE_TIMEOUT + 1);
+        messenger
+            .pending_messages
+            .lock()
+            .unwrap()
+            .insert(test_message.id(), (fake_time, tx));
+
+        messenger.check_timeouts();
+
+        let response = rx.await.unwrap();
+        assert_eq!(response, OnionMessageResponse::Continue);
+    }
+
+    #[tokio::test]
+    async fn test_multiple_subscribers() {
+        let messenger = Messenger::new();
+        let mut rx1 = messenger.subscribe();
+        let mut rx2 = messenger.subscribe();
+
+        let test_message = create_test_message(1, vec![1, 2, 3]);
+        let _response_rx = messenger.received_message(test_message.clone());
+
+        let received_message1 = rx1.recv().await.unwrap();
+        let received_message2 = rx2.recv().await.unwrap();
+
+        assert_eq!(received_message1.id(), test_message.id());
+        assert_eq!(received_message2.id(), test_message.id());
+    }
+
+    #[test]
+    fn test_nonexistent_message_response() {
+        let messenger = Messenger::new();
+        // Try to send a response for a message that doesn't exist; should not panic
+        messenger.send_response(999, OnionMessageResponse::Continue);
+    }
+}


### PR DESCRIPTION
So that the backend can `continue` onion message hooks and they can be handled by a different plugin (like the offers plugin in CLN itself)