### PR TITLE
feat: add cltv_expiry field to HTLC entities

### DIFF
--- a/migrations/2025-10-01-070121_htlc_cltv_expiry/down.sql
+++ b/migrations/2025-10-01-070121_htlc_cltv_expiry/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE htlcs DROP COLUMN cltv_expiry;

--- a/migrations/2025-10-01-070121_htlc_cltv_expiry/up.sql
+++ b/migrations/2025-10-01-070121_htlc_cltv_expiry/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE htlcs ADD COLUMN cltv_expiry INTEGER;

--- a/migrations_postgres/2025-10-01-070121_htlc_cltv_expiry/down.sql
+++ b/migrations_postgres/2025-10-01-070121_htlc_cltv_expiry/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE htlcs DROP COLUMN cltv_expiry;

--- a/migrations_postgres/2025-10-01-070121_htlc_cltv_expiry/up.sql
+++ b/migrations_postgres/2025-10-01-070121_htlc_cltv_expiry/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE htlcs ADD COLUMN cltv_expiry INTEGER;

--- a/protos/hold.proto
+++ b/protos/hold.proto
@@ -94,6 +94,7 @@ message Htlc {
   uint64 channel_id = 4;
   uint64 msat = 5;
   uint64 created_at = 6;
+  optional uint64 cltv_expiry = 7;
 }
 
 message Invoice {

--- a/src/database/helpers/invoice_helper.rs
+++ b/src/database/helpers/invoice_helper.rs
@@ -321,6 +321,7 @@ pub mod test {
             scid: "1".to_string(),
             channel_id: 1,
             msat: 1000,
+            cltv_expiry: 226,
         };
         helper.insert_htlc(&htlc_accepted).unwrap();
 
@@ -330,6 +331,7 @@ pub mod test {
             scid: "2".to_string(),
             channel_id: 2,
             msat: 1000,
+            cltv_expiry: 226,
         };
         helper.insert_htlc(&htlc_cancelled).unwrap();
 

--- a/src/database/model.rs
+++ b/src/database/model.rs
@@ -47,6 +47,7 @@ pub struct Htlc {
     pub scid: String,
     pub channel_id: i64,
     pub msat: i64,
+    pub cltv_expiry: Option<i64>,
     pub created_at: chrono::NaiveDateTime,
 }
 
@@ -57,6 +58,7 @@ pub struct HtlcInsertable {
     pub state: String,
     pub scid: String,
     pub channel_id: i64,
+    pub cltv_expiry: i64,
     pub msat: i64,
 }
 
@@ -375,6 +377,7 @@ mod test {
             scid: "".to_string(),
             channel_id: 0,
             msat: 21_000,
+            cltv_expiry: Some(226),
             created_at: Default::default(),
         });
         assert_eq!(invoice.amount_paid_msat(), 0);
@@ -386,6 +389,7 @@ mod test {
             scid: "".to_string(),
             channel_id: 0,
             msat: 10_000,
+            cltv_expiry: Some(226),
             created_at: Default::default(),
         });
         assert_eq!(invoice.amount_paid_msat(), 10_000);
@@ -397,6 +401,7 @@ mod test {
             scid: "".to_string(),
             channel_id: 0,
             msat: 10_000,
+            cltv_expiry: Some(226),
             created_at: Default::default(),
         });
         assert_eq!(invoice.amount_paid_msat(), 20_000);
@@ -423,6 +428,7 @@ mod test {
                     scid: "asdf".to_string(),
                     channel_id: 123,
                     msat: 0,
+                    cltv_expiry: Some(226),
                     created_at: Default::default(),
                 },
                 Htlc {
@@ -432,6 +438,7 @@ mod test {
                     scid: "some channel".to_string(),
                     channel_id: 21,
                     msat: 0,
+                    cltv_expiry: Some(226),
                     created_at: Default::default(),
                 },
             ],

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -19,6 +19,7 @@ diesel::table! {
         scid -> Text,
         channel_id -> BigInt,
         msat -> BigInt,
+        cltv_expiry -> Nullable<BigInt>,
         created_at -> Timestamp,
     }
 }

--- a/src/grpc/transformers.rs
+++ b/src/grpc/transformers.rs
@@ -12,6 +12,7 @@ impl From<Htlc> for hold::Htlc {
             scid: value.scid,
             channel_id: value.channel_id as u64,
             msat: value.msat as u64,
+            cltv_expiry: value.cltv_expiry.map(|cltv| cltv as u64),
             created_at: value.created_at.and_utc().timestamp() as u64,
         }
     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -204,6 +204,7 @@ where
             state: state.to_string(),
             scid: args.htlc.short_channel_id.clone(),
             channel_id: args.htlc.id as i64,
+            cltv_expiry: args.htlc.cltv_expiry as i64,
             msat: args.htlc.amount_msat as i64,
         }
     }


### PR DESCRIPTION
note: the columns are made nullable to ensure backward compatibility.